### PR TITLE
Update scripts to include EULA acceptance

### DIFF
--- a/0-start.sh
+++ b/0-start.sh
@@ -23,7 +23,8 @@ build_initialized_image() {
 
 startup_conjur() {
   docker-compose up -d
-  docker exec $CONJUR_BUILD_CONTAINER_NAME evoke configure master -h $CONJUR_MASTER_NAME -p $CONJUR_ADMIN_PASSWORD $CONJUR_ORG_ACCOUNT
+  docker exec $CONJUR_BUILD_CONTAINER_NAME evoke configure master --accept-eula \
+    -h $CONJUR_MASTER_NAME -p $CONJUR_ADMIN_PASSWORD $CONJUR_ORG_ACCOUNT
 }
 
 initialize_client_node() {

--- a/0-start.sh
+++ b/0-start.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 CONJUR_MASTER_IMAGE=conjur-appliance:5-intlzd
 CONJUR_BUILD_CONTAINER_NAME=conjur_master
-CONJUR_MASTER_NAME=conjur_master
+CONJUR_MASTER_NAME=conjur-master
 CONJUR_ADMIN_PASSWORD=Cyberark1
 CONJUR_ORG_ACCOUNT=dev
 

--- a/build/client_node/Dockerfile
+++ b/build/client_node/Dockerfile
@@ -4,6 +4,7 @@ FROM ubuntu:14.04
 RUN apt-get update -y \
     && apt-get install -y \
     curl \
+    wget \
     unzip \
     ansible \
     python-pip

--- a/build/conjur_master/build_initialized_master.sh
+++ b/build/conjur_master/build_initialized_master.sh
@@ -5,7 +5,7 @@ if [[ $# -ne 1 ]]; then
 fi
 CONJUR_COMMIT_IMAGE=$1
 CONJUR_BASE_IMAGE=registry2.itci.conjur.net/conjur-appliance:5.0-stable
-CONJUR_MASTER_NAME=conjur_master
+CONJUR_MASTER_NAME=conjur-master
 CONJUR_BUILD_CONTAINER_NAME=conjur_master
 CONJUR_ADMIN_PASSWORD=Cyberark1
 CONJUR_ORG_ACCOUNT=dev

--- a/build/conjur_master/build_initialized_master.sh
+++ b/build/conjur_master/build_initialized_master.sh
@@ -16,7 +16,8 @@ docker run -d --restart always \
 		-p "443:443" -p "636:636" -p "5432:5432" -p "5433:5433" \
 		$CONJUR_BASE_IMAGE
 
-docker exec $CONJUR_BUILD_CONTAINER_NAME evoke configure master -h $CONJUR_MASTER_NAME -p $CONJUR_ADMIN_PASSWORD $CONJUR_ORG_ACCOUNT
+docker exec $CONJUR_BUILD_CONTAINER_NAME evoke configure master --accept-eula \
+	-h $CONJUR_MASTER_NAME -p $CONJUR_ADMIN_PASSWORD $CONJUR_ORG_ACCOUNT
 
 sleep 5
 docker exec $CONJUR_BUILD_CONTAINER_NAME sv stop conjur

--- a/build/conjur_master/tryit.sh
+++ b/build/conjur_master/tryit.sh
@@ -1,5 +1,6 @@
 docker run --name conjur-appliance -d --security-opt seccomp=unconfined registry2.itci.conjur.net/conjur-appliance:5.0-stable
-docker exec conjur-appliance evoke configure master -h conjur-master -p secret dev
+docker exec conjur-appliance evoke configure master --accept-eula \
+  -h conjur-master -p secret dev
 docker exec conjur-appliance /opt/conjur/evoke/bin/wait_for_conjur
 docker exec conjur-appliance sv stop conjur
 docker exec conjur-appliance sv stop pg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
 
-  conjur_master:
+  conjur-master:
     image: conjur-appliance:5-latest
     container_name: conjur_master
     build: ./build/conjur_master

--- a/init.sh
+++ b/init.sh
@@ -6,7 +6,7 @@
 # - initializes variables 
 # - creates conjur* conjurization files in the mounted fs
 
-CONJUR_HOSTNAME=conjur_master
+CONJUR_HOSTNAME=conjur-master
 CONJUR_ORG_ACCOUNT=dev
 CONJUR_ADMIN_UNAME=admin
 CONJUR_ADMIN_PWD=Cyberark1


### PR DESCRIPTION
This PR updates the automation scripts to work correctly with the latest version of `evoke`, including EULA acceptance.